### PR TITLE
Add base64 encoding support for bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIB_NAME=pbrt-yojson
 OCAMLFIND_PKG_NAME=ocaml-protoc-yojson
 LIB_FILES+=pbrt_yojson
 LIB_DIR=src
-LIB_DEPS=yojson
+LIB_DEPS=yojson,base64
 
 test:
 	$(OCB) unit_tests.native

--- a/opam
+++ b/opam
@@ -21,5 +21,6 @@ depends: [
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "yojson" {>= "1.6.0"}
+  "base64"
 ]
 available: [ ocaml-version >= "4.02.1" & opam-version >= "1.2" ]

--- a/src/pbrt_yojson.ml
+++ b/src/pbrt_yojson.ml
@@ -72,11 +72,14 @@ let bool v record_name field_name =
   | `Null -> false
   | _ -> E.unexpected_json_type record_name field_name 
 
-let bytes _ record_name field_name = 
-  E.unexpected_json_type record_name field_name
+let bytes v record_name field_name =
+  string v record_name field_name
+  |> Base64.decode_exn
+  |> Bytes.of_string
 
 let make_bool v = `Bool  v
 let make_int v = `Int  v
 let make_float v = `Float  v
 let make_string v = `String  v
+let make_bytes s = make_string (s |> Bytes.to_string |> Base64.encode_exn ~pad:true)
 let make_list v = `List v

--- a/src/pbrt_yojson.mli
+++ b/src/pbrt_yojson.mli
@@ -34,4 +34,5 @@ val make_bool : bool -> Yojson.Basic.t
 val make_int : int -> Yojson.Basic.t
 val make_float : float -> Yojson.Basic.t
 val make_string : string -> Yojson.Basic.t
+val make_bytes: bytes -> Yojson.Basic.t
 val make_list : Yojson.Basic.t list -> Yojson.Basic.t


### PR DESCRIPTION
According to https://protobuf.dev/programming-guides/proto3/#json 'bytes' is base64 encoded with padding.
For decoding both with/without padding and standard/url-safe encoding is accepted.
TODO: for decoding might have to try another alphabet if standard failed, but the code here suffices for talking to 'etcd' over its JSON protocol.

Note that this uses a 'bytes' type on the OCaml side, for backward compatibility: 'string' would work just as well because binary values, including \0 are valid inside OCaml strings.
This does perform extra copying now that may be unnecessary if we change the type to be 'string' (can't use the unsafe version because we cannot guarantee lack of mutation).